### PR TITLE
feat(themes): theme matches device's

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,11 @@ class MyApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       theme: ThemeData(
+        brightness: Brightness.light,
         primarySwatch: Colors.blue,
+      ),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
       ),
       home: MainScreen(),
     );


### PR DESCRIPTION
Temporary (maybe) solution: match device's theme, no button